### PR TITLE
fix(collectors): Handle asyncio timeouts gracefully

### DIFF
--- a/ch_exporter/collectors.py
+++ b/ch_exporter/collectors.py
@@ -28,8 +28,9 @@ class MetricsGroupCollector:
 
     async def collect(self, node, url):
         logger.debug(f"Starting collection of {', '.join([metric.name for metric in self.metrics])}")
-        async with ClientSession():
+        async with ClientSession() as session:
             client = ChClient(
+                session=session,
                 url=url,
                 user=self._config.ch_user,
                 password=self._config.ch_password,

--- a/ch_exporter/collectors.py
+++ b/ch_exporter/collectors.py
@@ -48,5 +48,8 @@ class MetricsGroupCollector:
                     logger.exception(f"{self.metric_names}: Error while collecting metric: ", e)
                 except ClientConnectorError as e:
                     logger.exception(f"{self.metric_names}: HTTP Error reaching clickhouse {url}: ", e)
+                except asyncio.TimeoutError as e:
+                    logger.exception(f"{self.metric_names}: HTTP Timeout reaching clickhouse {url}: ", e)
+
                 time_taken = (now() - start_time).seconds
                 await asyncio.sleep(self.period - time_taken)


### PR DESCRIPTION
Handle asyncio timeouts gracefully to prevent crashes due to timeouts in metric collectors. This PR also fixes the "unclosed client session" warnings by passing the created ClientSession to ChClient.

```
2023-08-17T10:46:24+02:00	client_session: <aiohttp.client.ClientSession object at 0x7f7357d79410>
2023-08-17T10:46:24+02:00	  + Exception Group Traceback (most recent call last):
2023-08-17T10:46:24+02:00	  |   File "/app/main.py", line 32, in <module>
2023-08-17T10:46:24+02:00	  |     asyncio.run(run_loop())
2023-08-17T10:46:24+02:00	  |   File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
2023-08-17T10:46:24+02:00	  |     return runner.run(main)
2023-08-17T10:46:24+02:00	  |            ^^^^^^^^^^^^^^^^
2023-08-17T10:46:24+02:00	  |   File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
2023-08-17T10:46:24+02:00	  |     return self._loop.run_until_complete(task)
2023-08-17T10:46:24+02:00	  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-08-17T10:46:24+02:00	  |   File "/usr/local/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
2023-08-17T10:46:24+02:00	  |     return future.result()
2023-08-17T10:46:24+02:00	  |            ^^^^^^^^^^^^^^^
2023-08-17T10:46:24+02:00	  |   File "/app/main.py", line 21, in run_loop
2023-08-17T10:46:24+02:00	  |     async with TaskGroup() as tg:
2023-08-17T10:46:24+02:00	  |   File "/usr/local/lib/python3.11/asyncio/taskgroups.py", line 133, in __aexit__
2023-08-17T10:46:24+02:00	  |     raise me from None
2023-08-17T10:46:24+02:00	  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
2023-08-17T10:46:24+02:00	  +-+---------------- 1 ----------------
2023-08-17T10:46:24+02:00	    | Traceback (most recent call last):
2023-08-17T10:46:24+02:00	    |   File "/app/ch_exporter/collectors.py", line 40, in collect
2023-08-17T10:46:24+02:00	    |     result = await client.fetch(self.query)
2023-08-17T10:46:24+02:00	    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-08-17T10:46:24+02:00	    |   File "/app/.venv/lib/python3.11/site-packages/aiochclient/client.py", line 265, in fetch
2023-08-17T10:46:24+02:00	    |     return [
2023-08-17T10:46:24+02:00	    |            ^
2023-08-17T10:46:24+02:00	    |   File "/app/.venv/lib/python3.11/site-packages/aiochclient/client.py", line 265, in <listcomp>
2023-08-17T10:46:24+02:00	    |     return [
2023-08-17T10:46:24+02:00	    |            ^
2023-08-17T10:46:24+02:00	    |   File "/app/.venv/lib/python3.11/site-packages/aiochclient/client.py", line 185, in _execute
2023-08-17T10:46:24+02:00	    |     names=await response.__anext__(),
2023-08-17T10:46:24+02:00	    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-08-17T10:46:24+02:00	    |   File "/app/.venv/lib/python3.11/site-packages/aiochclient/http_clients/aiohttp.py", line 25, in post_return_lines
2023-08-17T10:46:24+02:00	    |     async with self._session.post(
2023-08-17T10:46:24+02:00	    |   File "/app/.venv/lib/python3.11/site-packages/aiohttp/client.py", line 1141, in __aenter__
2023-08-17T10:46:24+02:00	    |     self._resp = await self._coro
2023-08-17T10:46:24+02:00	    |                  ^^^^^^^^^^^^^^^^
2023-08-17T10:46:24+02:00	    |   File "/app/.venv/lib/python3.11/site-packages/aiohttp/client.py", line 560, in _request
2023-08-17T10:46:24+02:00	    |     await resp.start(conn)
2023-08-17T10:46:24+02:00	    |   File "/app/.venv/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 894, in start
2023-08-17T10:46:24+02:00	    |     with self._timer:
2023-08-17T10:46:24+02:00	    |   File "/app/.venv/lib/python3.11/site-packages/aiohttp/helpers.py", line 721, in __exit__
2023-08-17T10:46:24+02:00	    |     raise asyncio.TimeoutError from None
2023-08-17T10:46:24+02:00	    | TimeoutError
2023-08-17T10:46:24+02:00	    +------------------------------------
2023-08-17T10:46:24+02:00	Unclosed client session
2023-08-17T10:46:24+02:00	client_session: <aiohttp.client.ClientSession object at 0x7f73587cf850>
2023-08-17T10:46:24+02:00	Unclosed connector
2023-08-17T10:46:24+02:00	connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x7f73541303d0>, 5532027.659828572)]']
2023-08-17T10:46:24+02:00	connector: <aiohttp.connector.TCPConnector object at 0x7f73587cdd90>
2023-08-17T10:46:24+02:00	Unclosed client session
2023-08-17T10:46:24+02:00	client_session: <aiohttp.client.ClientSession object at 0x7f7357dd2950>
```