### PR TITLE
fix: Clear group collector metrics by node

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -1,5 +1,4 @@
 groups:
-9
   - metrics:
       - name: tables_size_bytes
         description: Current table size in bytes


### PR DESCRIPTION
When the group collector collects for n nodes, we cannot clear the prometheus metric when collecting for an individual node because this also removes metrics for all other nodes. This leads to flaky metrics as we only expose them for the node that was scraped last.

Since the public prometheus API does not provide functionality to get or clear existing label values by a subset of values (node in our case), we maintain the active labels by node on our own.